### PR TITLE
 feat: add opt-in data-generator feature to expose DataGenerator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,16 @@ homepage = "https://github.com/vihu/kneed"
 anyhow = "1"
 polyfit-rs = "0"
 thiserror = "1"
+rand = { version = "0", optional = true }
+rand_distr = { version = "0", optional = true }
 
 [dev-dependencies]
 approx = "0"
-rand = "0"
-rand_distr = "0"
 
 [features]
-testing = []
+default = []
+data-generator = ["dep:rand", "dep:rand_distr"]
+testing = ["data-generator"]
+
+[package.metadata.docs.rs]
+features = ["data-generator"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The code here aims to be a 1:1 match of [kneed](https://pypi.org/project/kneed/)
 
 ### Usage
 
+To use the `DataGenerator` API for generating test data, enable the `data-generator` feature:
+
+```toml
+[dependencies]
+kneed = { version = "1.0.0", features = ["data-generator"] }
+```
+
 General usage:
 
 ```rust
@@ -38,9 +45,10 @@ let kl = KneeLocator::new(x.to_vec(), y.to_vec(), 1.0, params);
 // kl.all_norm_elbows_y()
 ```
 
-Example from the paper:
+Example from the paper (requires `data-generator` feature):
 
 ```rust
+// This example requires the "data-generator" feature to be enabled
 let (x, y) = DataGenerator::figure2();
 
 let params = KneeLocatorParams::new(

--- a/src/data_generator.rs
+++ b/src/data_generator.rs
@@ -75,12 +75,12 @@ mod tests {
     fn test_data_generator_feature() {
         // Test that DataGenerator::figure2() works when feature is enabled
         let (x, y) = DataGenerator::figure2();
-        
+
         // Basic invariants
         assert_eq!(x.len(), 10, "x should have 10 elements");
         assert_eq!(y.len(), 10, "y should have 10 elements");
         assert_eq!(x.len(), y.len(), "x and y should have the same length");
-        
+
         // Check that x is non-empty and contains valid numbers
         assert!(!x.is_empty());
         assert!(!y.is_empty());

--- a/src/data_generator.rs
+++ b/src/data_generator.rs
@@ -70,6 +70,24 @@ mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
 
+    #[cfg(feature = "data-generator")]
+    #[test]
+    fn test_data_generator_feature() {
+        // Test that DataGenerator::figure2() works when feature is enabled
+        let (x, y) = DataGenerator::figure2();
+        
+        // Basic invariants
+        assert_eq!(x.len(), 10, "x should have 10 elements");
+        assert_eq!(y.len(), 10, "y should have 10 elements");
+        assert_eq!(x.len(), y.len(), "x and y should have the same length");
+        
+        // Check that x is non-empty and contains valid numbers
+        assert!(!x.is_empty());
+        assert!(!y.is_empty());
+        assert!(x.iter().all(|&val| val.is_finite()));
+        assert!(y.iter().all(|&val| val.is_finite()));
+    }
+
     fn assert_vec_abs_diff_eq(vec1: &[f64], vec2: &[f64]) {
         const EPSILON: f64 = 1e-7;
 

--- a/src/knee_locator.rs
+++ b/src/knee_locator.rs
@@ -507,10 +507,12 @@ where
 mod tests {
     use super::*;
 
-    #[cfg(feature = "testing")]
+    #[cfg(feature = "data-generator")]
     use crate::data_generator::DataGenerator;
     use approx::assert_abs_diff_eq;
+    #[cfg(feature = "data-generator")]
     use rand::prelude::*;
+    #[cfg(feature = "data-generator")]
     use rand_distr::{Distribution, Gamma};
 
     fn truncate_and_scale(
@@ -540,6 +542,7 @@ mod tests {
         (x, y)
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_figure2_interp1d() {
         let (x, y) = DataGenerator::figure2();
@@ -557,6 +560,7 @@ mod tests {
         assert_abs_diff_eq!(1.8965517241379306, kl.knee_y.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_figure2_polynomial() {
         let (x, y) = DataGenerator::figure2();
@@ -574,6 +578,7 @@ mod tests {
         assert_abs_diff_eq!(1.8965517241379306, kl.knee_y.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_noisy_gaussian() {
         let (x, y) = DataGenerator::noisy_gaussian(50.0, 10.0, 1000, 42);
@@ -588,6 +593,7 @@ mod tests {
         assert_abs_diff_eq!(62.25, kl.knee.unwrap(), epsilon = 0.1);
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_increasing_interp1d() {
         let (x, y) = DataGenerator::concave_increasing();
@@ -600,6 +606,7 @@ mod tests {
         assert_abs_diff_eq!(2.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_increasing_polynomial() {
         let (x, y) = DataGenerator::concave_increasing();
@@ -612,6 +619,7 @@ mod tests {
         assert_abs_diff_eq!(2.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_decreasing_interp1d() {
         let (x, y) = DataGenerator::concave_decreasing();
@@ -624,6 +632,7 @@ mod tests {
         assert_abs_diff_eq!(7.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_decreasing_polynomial() {
         let (x, y) = DataGenerator::concave_decreasing();
@@ -636,6 +645,7 @@ mod tests {
         assert_abs_diff_eq!(7.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_increasing_interp1d() {
         let (x, y) = DataGenerator::convex_increasing();
@@ -648,6 +658,7 @@ mod tests {
         assert_abs_diff_eq!(7.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_increasing_polynomial() {
         let (x, y) = DataGenerator::convex_increasing();
@@ -660,6 +671,7 @@ mod tests {
         assert_abs_diff_eq!(7.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_interp1d() {
         let (x, y) = DataGenerator::convex_decreasing();
@@ -672,6 +684,7 @@ mod tests {
         assert_abs_diff_eq!(2.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_polynomial() {
         let (x, y) = DataGenerator::convex_decreasing();
@@ -684,6 +697,7 @@ mod tests {
         assert_abs_diff_eq!(2.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_increasing_truncated_interp1d() {
         let (x, y) = DataGenerator::concave_increasing();
@@ -699,6 +713,7 @@ mod tests {
         assert_abs_diff_eq!(0.2, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_increasing_truncated_polynomial() {
         let (x, y) = DataGenerator::concave_increasing();
@@ -714,6 +729,7 @@ mod tests {
         assert_abs_diff_eq!(0.2, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_decreasing_truncated_interp1d() {
         let (x, y) = DataGenerator::concave_decreasing();
@@ -729,6 +745,7 @@ mod tests {
         assert_abs_diff_eq!(0.4, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_concave_decreasing_truncated_polynomial() {
         let (x, y) = DataGenerator::concave_decreasing();
@@ -744,6 +761,7 @@ mod tests {
         assert_abs_diff_eq!(0.4, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_increasing_truncated_interp1d() {
         let (x, y) = DataGenerator::convex_increasing();
@@ -759,6 +777,7 @@ mod tests {
         assert_abs_diff_eq!(0.4, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_increasing_truncated_polynomial() {
         let (x, y) = DataGenerator::convex_increasing();
@@ -774,6 +793,7 @@ mod tests {
         assert_abs_diff_eq!(0.4, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_truncated_interp1d() {
         let (x, y) = DataGenerator::convex_decreasing();
@@ -789,6 +809,7 @@ mod tests {
         assert_abs_diff_eq!(0.2, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_truncated_polynomial() {
         let (x, y) = DataGenerator::convex_decreasing();
@@ -804,6 +825,7 @@ mod tests {
         assert_abs_diff_eq!(0.2, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_bumpy_interp1d() {
         let (x, y) = DataGenerator::bumpy();
@@ -816,6 +838,7 @@ mod tests {
         assert_abs_diff_eq!(26.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_convex_decreasing_bumpy_polynomial() {
         let (x, y) = DataGenerator::bumpy();
@@ -828,6 +851,7 @@ mod tests {
         assert_abs_diff_eq!(28.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_gamma_online() {
         let mut rng = StdRng::seed_from_u64(23);
@@ -855,6 +879,7 @@ mod tests {
         assert_abs_diff_eq!(497.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_gamma_offline() {
         let mut rng = StdRng::seed_from_u64(23);
@@ -882,6 +907,7 @@ mod tests {
         assert_abs_diff_eq!(71.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_sensitivity() {
         let seed = 23;
@@ -983,6 +1009,7 @@ mod tests {
         assert_abs_diff_eq!(8.0, kl2.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_y() {
         let (x, y) = DataGenerator::figure2();
@@ -1154,6 +1181,7 @@ mod tests {
         assert_abs_diff_eq!(73.0, kl.knee.unwrap());
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_all_knees() {
         let (x, y) = DataGenerator::bumpy();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod knee_locator;
 
-#[cfg(all(feature = "testing", test))]
-mod data_generator;
+#[cfg(feature = "data-generator")]
+pub mod data_generator;
+
+#[cfg(feature = "data-generator")]
+pub use data_generator::DataGenerator;
 
 #[cfg(test)]
 mod shape_detector;

--- a/src/shape_detector.rs
+++ b/src/shape_detector.rs
@@ -56,7 +56,7 @@ fn find_shape(x: &[f64], y: &[f64]) -> Shape {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "testing")]
+    #[cfg(feature = "data-generator")]
     use crate::data_generator::DataGenerator;
     use crate::knee_locator::{ValidCurve, ValidDirection};
 
@@ -127,6 +127,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "data-generator")]
     #[test]
     fn test_find_shape() {
         let (x, y) = DataGenerator::concave_increasing();


### PR DESCRIPTION
Add a new optional Cargo feature data-generator that exposes the DataGenerator API to crate users. Previously, DataGenerator was only available during testing.

Changes:
- Move rand and rand_distr from dev-dependencies to optional dependencies
- Add data-generator feature that enables rand and rand_distr
- Make testing feature include data-generator to preserve test workflows
- Conditionally compile and export data_generator module based on feature
- Gate all tests using DataGenerator or rand behind the feature
- Update README with feature usage instructions and examples
- Add docs.rs metadata to include feature in documentation

This allows users to opt-in to DataGenerator functionality without pulling in rand/rand_distr dependencies by default, reducing the default dependency footprint of the crate.

Tests pass both with and without the feature enabled.