### PR TITLE
feat: add automatic shape detection for KneeLocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,50 +8,84 @@ The code here aims to be a 1:1 match of [kneed](https://pypi.org/project/kneed/)
 
 ### Usage
 
-General usage:
+#### Automatic shape detection (recommended)
+
+The easiest way to use the library is with automatic shape detection, which analyzes your data
+to determine the curve direction and type:
 
 ```rust
-// Provide your x: Vec<f64> and y: Vec<f64>
-let x = [1.0, 2.0, 3.0];
-let y = [10.0, 20.0, 30.0];
-let params = KneeLocatorParams::new(
-    ValidCurve::Concave,
-    ValidDirection::Increasing,
-    InterpMethod::Interp1d,
-);
+use kneed::knee_locator::KneeLocator;
 
-// Instantiate KneeLocator
-let kl = KneeLocator::new(x.to_vec(), y.to_vec(), 1.0, params);
+let x = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+let y = vec![0.0, 60.0, 80.0, 85.0, 90.0, 95.0, 96.0, 97.0, 98.0, 99.0];
 
-// After instantiation, you can invoke the following:
-// kl.knee
-// kl.knee_y
-// kl.norm_knee
-// kl.norm_knee_y
-// kl.elbow()
-// kl.norm_elbow()
-// kl.elbow_y()
-// kl.norm_elbow_y()
-// kl.all_elbows()
-// kl.all_norm_elbows()
-// kl.all_elbows_y()
-// kl.all_norm_elbows_y()
+// Auto-detect curve shape and find the knee
+let kl = KneeLocator::auto(x, y, 1.0).unwrap();
+
+println!("Knee detected at x = {:?}", kl.knee);  // Some(2.0)
 ```
 
-Example from the paper:
+#### Manual parameter specification
+
+For full control, you can manually specify the curve parameters:
 
 ```rust
-let (x, y) = DataGenerator::figure2();
+use kneed::knee_locator::{KneeLocator, KneeLocatorParams, ValidCurve, ValidDirection, InterpMethod};
+
+let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+let y = vec![10.0, 20.0, 30.0, 40.0, 50.0];
 
 let params = KneeLocatorParams::new(
     ValidCurve::Concave,
     ValidDirection::Increasing,
     InterpMethod::Interp1d,
 );
-let kneedle = KneeLocator::new(x.to_vec(), y.to_vec(), 1.0, params);
 
-assert_relative_eq!(0.222222222222222, kneedle.knee.unwrap());
-assert_relative_eq!(1.8965517241379306, kneedle.knee_y.unwrap());
+let kl = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+// Available methods after instantiation:
+// kl.knee           - The detected knee point (x-value)
+// kl.knee_y         - The y-value at the knee
+// kl.norm_knee      - Normalized knee x-value
+// kl.norm_knee_y    - Normalized knee y-value
+// kl.elbow()        - Alias for knee
+// kl.all_elbows()   - All detected elbows (in online mode)
+```
+
+#### Shape detection utility
+
+You can also use the shape detection function directly:
+
+```rust
+use kneed::shape_detector::find_shape;
+use kneed::knee_locator::{ValidDirection, ValidCurve};
+
+let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+let y = vec![1.0, 1.5, 1.8, 1.9, 2.0];
+
+let (direction, curve) = find_shape(&x, &y);
+assert_eq!(direction, ValidDirection::Increasing);
+assert_eq!(curve, ValidCurve::Concave);
+```
+
+### Example from the paper
+
+```rust
+use kneed::knee_locator::{KneeLocator, KneeLocatorParams, ValidCurve, ValidDirection, InterpMethod};
+
+// Figure 2 data from the Kneedle paper
+let x: Vec<f64> = (0..10).map(|i| i as f64 / 9.0).collect();
+let y: Vec<f64> = x.iter().map(|&xi| -1.0 / (xi + 0.1) + 5.0).collect();
+
+let params = KneeLocatorParams::new(
+    ValidCurve::Concave,
+    ValidDirection::Increasing,
+    InterpMethod::Interp1d,
+);
+let kneedle = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+assert!((kneedle.knee.unwrap() - 0.222222222222222).abs() < 1e-10);
+assert!((kneedle.knee_y.unwrap() - 1.8965517241379306).abs() < 1e-10);
 ```
 
 ### Credits

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ use kneed::knee_locator::{KneeLocator, KneeLocatorParams, ValidCurve, ValidDirec
 
 // Figure 2 data from the Kneedle paper
 let x: Vec<f64> = (0..10).map(|i| i as f64 / 9.0).collect();
-let y: Vec<f64> = x.iter().map(|&xi| -1.0 / (xi + 0.1) + 5.0).collect();
 Example from the paper (requires `data-generator` feature):
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ use kneed::knee_locator::{KneeLocator, KneeLocatorParams, ValidCurve, ValidDirec
 
 // Figure 2 data from the Kneedle paper
 let x: Vec<f64> = (0..10).map(|i| i as f64 / 9.0).collect();
+let y: Vec<f64> = x.iter().map(|&xi| -1.0 / (xi + 0.1) + 5.0).collect();
 Example from the paper (requires `data-generator` feature):
 
-```rust
 // This example requires the "data-generator" feature to be enabled
 let (x, y) = DataGenerator::figure2();
 

--- a/src/knee_locator.rs
+++ b/src/knee_locator.rs
@@ -31,6 +31,8 @@ use anyhow::{bail, Result};
 use polyfit_rs::polyfit_rs::polyfit;
 use thiserror::Error;
 
+use crate::shape_detector::find_shape;
+
 /// Errors specific to the KneeLocator.
 #[derive(Error, Debug)]
 pub enum KneeLocatorError {
@@ -171,6 +173,91 @@ impl KneeLocator {
     /// Creates a new KneeLocator instance with default parameters.
     pub fn new(x: Vec<f64>, y: Vec<f64>, s: f64, params: KneeLocatorParams) -> Result<Self> {
         Self::parameterized_new(x, y, s, params, false, 7)
+    }
+
+    /// Creates a new KneeLocator instance with automatic shape detection.
+    ///
+    /// This method analyzes the input data to automatically determine the curve direction
+    /// (increasing/decreasing) and type (convex/concave), eliminating the need to manually
+    /// specify these parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - A vector of x-coordinates
+    /// * `y` - A vector of y-coordinates (must be the same length as `x`)
+    /// * `s` - Sensitivity parameter. A higher value means more sensitivity to detecting knees.
+    ///         Recommended values are between 1.0 and 10.0.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the `KneeLocator` instance, or an error if the input is invalid.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kneed::knee_locator::KneeLocator;
+    ///
+    /// let x = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    /// let y = vec![0.0, 60.0, 80.0, 85.0, 90.0, 95.0, 96.0, 97.0, 98.0, 99.0];
+    ///
+    /// let kl = KneeLocator::auto(x, y, 1.0).unwrap();
+    /// assert!(kl.knee.is_some());
+    /// ```
+    pub fn auto(x: Vec<f64>, y: Vec<f64>, s: f64) -> Result<Self> {
+        Self::auto_with_interp(x, y, s, InterpMethod::Interp1d)
+    }
+
+    /// Creates a new KneeLocator instance with automatic shape detection and a specified
+    /// interpolation method.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - A vector of x-coordinates
+    /// * `y` - A vector of y-coordinates (must be the same length as `x`)
+    /// * `s` - Sensitivity parameter
+    /// * `interp_method` - The interpolation method to use
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the `KneeLocator` instance, or an error if the input is invalid.
+    pub fn auto_with_interp(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        s: f64,
+        interp_method: InterpMethod,
+    ) -> Result<Self> {
+        Self::check_x_y(&x, &y)?;
+        let (direction, curve) = find_shape(&x, &y);
+        let params = KneeLocatorParams::new(curve, direction, interp_method);
+        Self::parameterized_new(x, y, s, params, false, 7)
+    }
+
+    /// Creates a new KneeLocator instance with automatic shape detection and full parameter control.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - A vector of x-coordinates
+    /// * `y` - A vector of y-coordinates (must be the same length as `x`)
+    /// * `s` - Sensitivity parameter
+    /// * `interp_method` - The interpolation method to use
+    /// * `online` - If true, detects the last knee; if false, detects the first knee
+    /// * `polynomial_degree` - Degree of polynomial for polynomial interpolation
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the `KneeLocator` instance, or an error if the input is invalid.
+    pub fn auto_parameterized(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        s: f64,
+        interp_method: InterpMethod,
+        online: bool,
+        polynomial_degree: usize,
+    ) -> Result<Self> {
+        Self::check_x_y(&x, &y)?;
+        let (direction, curve) = find_shape(&x, &y);
+        let params = KneeLocatorParams::new(curve, direction, interp_method);
+        Self::parameterized_new(x, y, s, params, online, polynomial_degree)
     }
 
     /// Creates a new KneeLocator instance with custom parameters.
@@ -1239,5 +1326,104 @@ mod tests {
         // Test valid input
         let result = KneeLocator::new(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0], 1.0, params);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_auto_concave_increasing() {
+        let (x, y) = DataGenerator::concave_increasing();
+        let kl = KneeLocator::auto(x.clone(), y.clone(), 1.0).unwrap();
+
+        // Should match the result from manually specifying the correct params
+        let params = KneeLocatorParams::new(
+            ValidCurve::Concave,
+            ValidDirection::Increasing,
+            InterpMethod::Interp1d,
+        );
+        let kl_manual = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+        assert_eq!(kl.knee, kl_manual.knee);
+        assert_abs_diff_eq!(2.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_concave_decreasing() {
+        let (x, y) = DataGenerator::concave_decreasing();
+        let kl = KneeLocator::auto(x.clone(), y.clone(), 1.0).unwrap();
+
+        let params = KneeLocatorParams::new(
+            ValidCurve::Concave,
+            ValidDirection::Decreasing,
+            InterpMethod::Interp1d,
+        );
+        let kl_manual = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+        assert_eq!(kl.knee, kl_manual.knee);
+        assert_abs_diff_eq!(7.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_convex_increasing() {
+        let (x, y) = DataGenerator::convex_increasing();
+        let kl = KneeLocator::auto(x.clone(), y.clone(), 1.0).unwrap();
+
+        let params = KneeLocatorParams::new(
+            ValidCurve::Convex,
+            ValidDirection::Increasing,
+            InterpMethod::Interp1d,
+        );
+        let kl_manual = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+        assert_eq!(kl.knee, kl_manual.knee);
+        assert_abs_diff_eq!(7.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_convex_decreasing() {
+        let (x, y) = DataGenerator::convex_decreasing();
+        let kl = KneeLocator::auto(x.clone(), y.clone(), 1.0).unwrap();
+
+        let params = KneeLocatorParams::new(
+            ValidCurve::Convex,
+            ValidDirection::Decreasing,
+            InterpMethod::Interp1d,
+        );
+        let kl_manual = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+        assert_eq!(kl.knee, kl_manual.knee);
+        assert_abs_diff_eq!(2.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_bumpy() {
+        let (x, y) = DataGenerator::bumpy();
+        let kl = KneeLocator::auto(x.clone(), y.clone(), 1.0).unwrap();
+
+        let params = KneeLocatorParams::new(
+            ValidCurve::Convex,
+            ValidDirection::Decreasing,
+            InterpMethod::Interp1d,
+        );
+        let kl_manual = KneeLocator::new(x, y, 1.0, params).unwrap();
+
+        assert_eq!(kl.knee, kl_manual.knee);
+        assert_abs_diff_eq!(26.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_with_polynomial_interp() {
+        let (x, y) = DataGenerator::concave_increasing();
+        let kl = KneeLocator::auto_with_interp(x, y, 1.0, InterpMethod::Polynomial).unwrap();
+        assert_abs_diff_eq!(2.0, kl.knee.unwrap());
+    }
+
+    #[test]
+    fn test_auto_input_validation() {
+        // Test empty vectors
+        let result = KneeLocator::auto(vec![], vec![], 1.0);
+        assert!(result.is_err());
+
+        // Test unequal lengths
+        let result = KneeLocator::auto(vec![1.0, 2.0], vec![1.0, 2.0, 3.0], 1.0);
+        assert!(result.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,8 @@
 pub mod knee_locator;
 pub mod shape_detector;
 
-#[cfg(all(feature = "testing", test))]
+#[cfg(any(all(feature = "testing", test), feature = "data-generator"))]
 mod data_generator;
-#[cfg(feature = "data-generator")]
-pub mod data_generator;
 
 #[cfg(feature = "data-generator")]
 pub use data_generator::DataGenerator;
-
-#[cfg(test)]
-mod shape_detector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 pub mod knee_locator;
+pub mod shape_detector;
 
 #[cfg(all(feature = "testing", test))]
 mod data_generator;
-
-#[cfg(test)]
-mod shape_detector;

--- a/src/shape_detector.rs
+++ b/src/shape_detector.rs
@@ -1,11 +1,49 @@
-#![allow(dead_code)]
+//! # Shape Detection for Curves
+//!
+//! This module provides functionality to automatically detect the shape of a curve,
+//! determining both its direction (increasing/decreasing) and curvature (convex/concave).
+//!
+//! This is useful when you want to use the [`KneeLocator`](crate::knee_locator::KneeLocator)
+//! without manually specifying the curve parameters.
 
 use crate::knee_locator::{ValidCurve, ValidDirection};
 
-type Shape = (ValidDirection, ValidCurve);
+/// A tuple representing the detected shape: (direction, curve type).
+pub type Shape = (ValidDirection, ValidCurve);
 
 /// Detect the direction and curve type of the line.
-fn find_shape(x: &[f64], y: &[f64]) -> Shape {
+///
+/// This function analyzes the input data to determine:
+/// - **Direction**: Whether the curve is increasing or decreasing overall
+/// - **Curve type**: Whether the curve is convex or concave
+///
+/// # Arguments
+///
+/// * `x` - A slice of x-coordinates (must be the same length as `y`)
+/// * `y` - A slice of y-coordinates (must be the same length as `x`)
+///
+/// # Returns
+///
+/// A tuple of `(ValidDirection, ValidCurve)` representing the detected shape.
+///
+/// # Panics
+///
+/// Panics if `x` and `y` have different lengths.
+///
+/// # Example
+///
+/// ```
+/// use kneed::shape_detector::find_shape;
+/// use kneed::knee_locator::{ValidDirection, ValidCurve};
+///
+/// let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+/// let y = vec![1.0, 1.5, 1.8, 1.9, 2.0];  // Concave increasing curve
+///
+/// let (direction, curve) = find_shape(&x, &y);
+/// assert_eq!(direction, ValidDirection::Increasing);
+/// assert_eq!(curve, ValidCurve::Concave);
+/// ```
+pub fn find_shape(x: &[f64], y: &[f64]) -> Shape {
     assert_eq!(x.len(), y.len(), "x and y must have the same length");
 
     // Perform polynomial fitting


### PR DESCRIPTION
- Make shape_detector module public with find_shape() function
- Add KneeLocator::auto() for automatic curve shape detection
- Add KneeLocator::auto_with_interp() for auto-detection with custom interpolation
- Add KneeLocator::auto_parameterized() for full parameter control with auto-detection
- Add comprehensive tests for all auto-detection methods
- Update README with new usage examples